### PR TITLE
Fix update dialogue not releasing semaphore, which causes a deadlock …

### DIFF
--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -160,6 +160,7 @@ class UpdateDlg(Qt.QDialog):
 
 	@Qt.pyqtSlot(int, Qt.QVariant)
 	def onUpdateFinished(self, addon, result):
+		self.sem.release()
 		value = self.progress.value() + 1
 		self.progress.setValue(value)
 		self.updateFinished.emit(addon, result)


### PR DESCRIPTION
…when number of updates < max number of threads.