### PR TITLE
Fix for #9. Able to properly remove addons

### DIFF
--- a/modules/application.py
+++ b/modules/application.py
@@ -354,16 +354,20 @@ class MainWidget(Qt.QMainWindow):
             parent = "{}/Interface/AddOns".format(str(settings.value(defines.WOW_FOLDER_KEY, defines.WOW_FOLDER_DEFAULT)))
             contents = os.listdir(parent)
             addonName =  str(self.addonList.item(row, 0).text())
+            deleted = False
             for item in contents:
                 itemDir = "{}/{}".format(parent, item)
                 if os.path.isdir(itemDir) and not item.lower().startswith("blizzard_"):
                     toc = "{}/{}.toc".format(itemDir, item)
                     if os.path.exists(toc):
                         tmp = self.extractAddonMetadataFromTOC(toc)
-                        if re.search(tmp[0], addonName) != None:
+                        if re.match(tmp[0], addonName) != None:
                             rmtree(itemDir)
-            if addonName == "InFlight Taxi Timer":
-                rmtree("{}/InFlight_Load".format(parent))
+                            deleted = True
+            if not deleted:
+                Qt.QMessageBox.question(self, "No addons removed",
+                                        str(self.tr("No addons matching {} found.\nManual deletion required.")).format(addonName),
+                                        Qt.QMessageBox.Ok)
             self.addonList.removeRow(row)
             self.saveAddons()
 

--- a/modules/application.py
+++ b/modules/application.py
@@ -5,6 +5,7 @@ import sys
 import json
 import os
 import re
+from shutil import rmtree
 from urllib.parse import urlparse
 import urllib
 from urllib.request import build_opener, HTTPCookieProcessor, HTTPError
@@ -349,6 +350,20 @@ class MainWidget(Qt.QMainWindow):
                                              str(self.addonList.item(row, 0).text())),
                                          Qt.QMessageBox.Yes, Qt.QMessageBox.No)
         if answer == Qt.QMessageBox.Yes:
+            settings = Qt.QSettings()
+            parent = "{}/Interface/AddOns".format(str(settings.value(defines.WOW_FOLDER_KEY, defines.WOW_FOLDER_DEFAULT)))
+            contents = os.listdir(parent)
+            addonName =  str(self.addonList.item(row, 0).text())
+            for item in contents:
+                itemDir = "{}/{}".format(parent, item)
+                if os.path.isdir(itemDir) and not item.lower().startswith("blizzard_"):
+                    toc = "{}/{}.toc".format(itemDir, item)
+                    if os.path.exists(toc):
+                        tmp = self.extractAddonMetadataFromTOC(toc)
+                        if re.search(tmp[0], addonName) != None:
+                            rmtree(itemDir)
+            if addonName == "InFlight Taxi Timer":
+                rmtree("{}/InFlight_Load".format(parent))
             self.addonList.removeRow(row)
             self.saveAddons()
 


### PR DESCRIPTION
So far InFlight is the only addon I've encountered that doesn't get all folders removed, because of the fact the addon gives you two folders with different titles in the .toc files:
`## Title: InFlight`
`## Title: InFlight_Load`
I am unsure of how to resolve this without adding exceptions to the code.