### PR TITLE
Remove extraneous percent signs from progress text.

### DIFF
--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -305,7 +305,7 @@ class UpdateCatalogDlg(Qt.QDialog):
     def onProgress(self, foundAddons):
         value = self.progress.value() + 1
         self.progress.setValue(value)
-        self.progress.setFormat(self.tr("%%p%% - found Addons: {}").format(foundAddons))
+        self.progress.setFormat(self.tr("%p% - found Addons: {}").format(foundAddons))
 
     @Qt.pyqtSlot(Qt.QVariant)
     def onUpdateCatalogFinished(self, addons):


### PR DESCRIPTION
See https://github.com/ephraim/lcurse/issues/35.

Not sure if these was a change in the way the formatting code functions (not a big python guy). Perhaps it needs to have version checks on tr()?