### PR TITLE
Addons with multiple modules show up multiple times in list

### DIFF
--- a/modules/application.py
+++ b/modules/application.py
@@ -188,7 +188,7 @@ class MainWidget(Qt.QMainWindow):
         (name, uri, version, curseId) = ("", "", "", "")
         title_re = re.compile(r"^## Title: (.*)$")
         curse_title_re = re.compile(r"^## X-Curse-Project-Name: (.*)$")
-        curse_title_re_partof = re.compile(r"^## X-Part-Of:  (.*)$")
+        title_re_partof = re.compile(r"^## X-Part-Of: (.*)$")
         curse_version_re = re.compile(r"^## X-Curse-Packaged-Version: (.*)$")
         version_re = re.compile(r"^## Version: (.*)$")
         curse_re = re.compile(r"^## X-Curse-Project-ID: (.*)$")
@@ -207,12 +207,13 @@ class MainWidget(Qt.QMainWindow):
                         name = m.group(1)
                         line = f.readline()
                         continue
-                else: #check if partof tag exists, replace package name with partof name
-                    m_partof = curse_title_re_partof.match(line)
-                    if m_partof != "":
+                else:
+                    m_partof = title_re_partof.match(line)
+                    if m_partof != None:
                         name = m_partof.group(1)
                         line = f.readline()
                         continue
+
                 m = curse_version_re.match(line)
                 if m != None:
                     version = m.group(1)

--- a/modules/application.py
+++ b/modules/application.py
@@ -188,6 +188,7 @@ class MainWidget(Qt.QMainWindow):
         (name, uri, version, curseId) = ("", "", "", "")
         title_re = re.compile(r"^## Title: (.*)$")
         curse_title_re = re.compile(r"^## X-Curse-Project-Name: (.*)$")
+        curse_title_re_partof = re.compile(r"^## X-Part-Of:  (.*)$")
         curse_version_re = re.compile(r"^## X-Curse-Packaged-Version: (.*)$")
         version_re = re.compile(r"^## Version: (.*)$")
         curse_re = re.compile(r"^## X-Curse-Project-ID: (.*)$")
@@ -204,6 +205,12 @@ class MainWidget(Qt.QMainWindow):
                     m = title_re.match(line)
                     if m != None:
                         name = m.group(1)
+                        line = f.readline()
+                        continue
+                else: #check if partof tag exists, replace package name with partof name
+                    m_partof = curse_title_re_partof.match(line)
+                    if m_partof != "":
+                        name = m_partof.group(1)
                         line = f.readline()
                         continue
                 m = curse_version_re.match(line)


### PR DESCRIPTION
Found that with some addons (Auctioneer to be specific), multiple modules show up in the list of addons. These are all bundled with the main addon with different names, and therefore do not have a resolvable URL. 

Downloading the main addon should include all of these modules, and they should all be updated fine.

Check if 'partof' tag exists in .toc file, replace addon name with 'partof' name. Currently an issue (bug) with addons that come with several modules (eg. Auctioneer)