### PR TITLE
Addon partof package

### DIFF
--- a/modules/application.py
+++ b/modules/application.py
@@ -188,6 +188,7 @@ class MainWidget(Qt.QMainWindow):
         (name, uri, version, curseId) = ("", "", "", "")
         title_re = re.compile(r"^## Title: (.*)$")
         curse_title_re = re.compile(r"^## X-Curse-Project-Name: (.*)$")
+        title_re_partof = re.compile(r"^## X-Part-Of: (.*)$")
         curse_version_re = re.compile(r"^## X-Curse-Packaged-Version: (.*)$")
         version_re = re.compile(r"^## Version: (.*)$")
         curse_re = re.compile(r"^## X-Curse-Project-ID: (.*)$")
@@ -206,6 +207,14 @@ class MainWidget(Qt.QMainWindow):
                         name = m.group(1)
                         line = f.readline()
                         continue
+                else:
+                    #check if .toc has partof tag, replace name for addons with multiple modules
+                    m_partof = title_re_partof.match(line)
+                    if m_partof != None:
+                        name = m_partof.group(1) + " (bundled)"
+                        line = f.readline()
+                        continue
+
                 m = curse_version_re.match(line)
                 if m != None:
                     version = m.group(1)
@@ -227,7 +236,7 @@ class MainWidget(Qt.QMainWindow):
         name = self.removeStupidStuff(name)
         curseId = self.removeStupidStuff(curseId)
 
-        uri = "http://mods.curse.com/addons/wow/{}".format(name.lower().replace(" ", "-"))
+        uri = "http://mods.curse.com/addons/wow/{}".format(name.lower().replace(" (bundled)","").replace(" ", "-"))
         if curseId != "":
             uri = "http://mods.curse.com/addons/wow/{}".format(curseId)
 
@@ -402,7 +411,7 @@ class MainWidget(Qt.QMainWindow):
                     to_delete = '\n'.join(potential_deletions)
                     removal = Qt.QMessageBox.question(self, "Potential deletion candidates found",
                                             str(self.tr("Remove the following addons as well?\n{}")).format(to_delete),
-                                            Qt.QMessageBox.Yes, Qt.QMessageBox.No)    
+                                            Qt.QMessageBox.Yes, Qt.QMessageBox.No)
                     if removal == Qt.QMessageBox.Yes:
                         for p in potential_deletions:
                             all_rows = self.addonList.rowCount()


### PR DESCRIPTION
Here we go this time... hopefully.

I noticed with some addons (Auctioneer specifically) that come with several modules, that the URL generated for updates was incorrect, since it was based off of the addon's title in the .toc file.

For this addon, the .toc has an extra tag called X-Part-Of with the name of the correct full addon.

Listing all of these single modules under one name allows the URL to be generated correctly, and updates all of the single modules since they are packaged together with it.

I've just added a small section that notifies the user that the addon is a bundle, and allows the addon to be updated.