### PR TITLE
Added support for an unattended update mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ Simply:
 ```bash
 pipenv run ./lcurse
 ```
+
+### Unattended mode
+
+You may also run `lcurse` in "unattended mode" once you have set it up. This
+will update all your addons and then exit. Use
+```bash
+pipenv run ./lcurse --auto-update
+```

--- a/lcurse
+++ b/lcurse
@@ -46,7 +46,12 @@ if __name__ == "__main__":
     mainWidget = application.MainWidget()
     try:
         mainWidget.show()
-        ret = app.exec_()
+        if len(sys.argv) > 1 and sys.argv[1] == "--auto-update":
+            mainWidget.hide()
+            mainWidget.updateAddons()
+            ret = 0
+        else:
+            ret = app.exec_()
         mainWidget.saveAddons()
     except Exception as e:
         print(str(e))


### PR DESCRIPTION
Added an unattended mode, so that addons can be auto-updated without having to manually open lcurse. Running `lcurse --auto-update` will start lcurse (without the main window), update all addons, then exit.