### PR TITLE
Several changes for the latest Curse and WoW versions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,5 +7,6 @@ python_version = '3.6'
 
 [packages]
 beautifulsoup4 = '>4.5.3'
+cfscrape = '*'
 lxml = '>3.6'
 PyQt5 = '>5.7'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ But at least the update is then done via the usuall lcurse way.
 * pipenv
 * PyQt5
 * bs4
+* cfscrape
 * lxml
 
 All requirements can be installed with:

--- a/modules/application.py
+++ b/modules/application.py
@@ -294,9 +294,9 @@ class MainWidget(Qt.QMainWindow):
         name = self.removeStupidStuff(name)
         curseId = self.removeStupidStuff(curseId)
         
-        uri = "http://www.curseforge.com/wow/addons/{}".format(name.lower().replace(" ", "-"))
+        uri = "https://www.curseforge.com/wow/addons/{}".format(name.lower().replace(" ", "-"))
         if curseId:
-            uri = "http://www.curseforge.com/wow/addons/{}".format(curseId)
+            uri = "https://www.curseforge.com/wow/addons/{}".format(curseId)
         
             #return ["", "", "", ""]
 

--- a/modules/application.py
+++ b/modules/application.py
@@ -367,12 +367,9 @@ class MainWidget(Qt.QMainWindow):
                     if tmp[0] == "":
                         continue
                     (name, uri, version, tocVersion) = tmp
-                    row = self.addonList.rowCount()
                     addons = self.addonList.findItems(name, Qt.Qt.MatchExactly)
                     if not addons:
-                        self.addonList.setRowCount(row + 1)
-                        self.insertAddon(row, name, uri, version, tocVersion, False)
-                        self.setRowColor(row, Qt.Qt.cyan)
+                        self.insertAddon(name, uri, version, tocVersion, False)
                     elif tocVersion:
                         for addon in addons:
                             self.addonList.item(addon.row(), 3).setText(tocVersion)
@@ -383,7 +380,10 @@ class MainWidget(Qt.QMainWindow):
         pref = preferences.PreferencesDlg(self)
         pref.exec_()
 
-    def insertAddon(self, row, name, uri, version, tocVersion, allowBeta):
+    def insertAddon(self, name, uri, version, tocVersion, allowBeta):
+        self.addonList.setSortingEnabled(False)
+        row = self.addonList.rowCount()
+        self.addonList.insertRow(row)
         self.addonList.setItem(row, 0, Qt.QTableWidgetItem(name))
         self.addonList.setItem(row, 1, Qt.QTableWidgetItem(uri))
         self.addonList.setItem(row, 2, Qt.QTableWidgetItem(version))
@@ -391,6 +391,8 @@ class MainWidget(Qt.QMainWindow):
         allowBetaItem = Qt.QTableWidgetItem()
         allowBetaItem.setCheckState(Qt.Qt.Checked if allowBeta else Qt.Qt.Unchecked)
         self.addonList.setItem(row, 4, allowBetaItem)
+        self.setRowColor(row, Qt.Qt.cyan)
+        self.addonList.setSortingEnabled(True)
 
     def loadAddonCatalog(self):
         if os.path.exists(defines.LCURSE_ADDON_CATALOG):
@@ -507,15 +509,7 @@ class MainWidget(Qt.QMainWindow):
                 name = os.path.basename(url)[:-4]
 
         if name:
-            newrow = self.addonList.rowCount()
-            self.addonList.insertRow(newrow)
-            self.addonList.setItem(newrow, 0, Qt.QTableWidgetItem(name))
-            self.addonList.setItem(newrow, 1, Qt.QTableWidgetItem(url))
-            self.addonList.setItem(newrow, 2, Qt.QTableWidgetItem(""))
-            self.addonList.setItem(newrow, 3, Qt.QTableWidgetItem(""))
-            allowBetaItem = Qt.QTableWidgetItem()
-            allowBetaItem.setCheckState(Qt.Qt.Unchecked)
-            self.addonList.setItem(newrow, 4, allowBetaItem)
+            self.insertAddon(name, url, "", "", False)
 
     def updateDatabaseFormat(self,oldVersion):
         if oldVersion != defines.LCURSE_DBVERSION:

--- a/modules/application.py
+++ b/modules/application.py
@@ -702,7 +702,7 @@ class MainWidget(Qt.QMainWindow):
             self.saveAddons()
 
     def updateAllAddons(self):
-        self.updateAddons(rows=iter(range(self.addonList.rowCount())))
+        self.updateAddons(rows=range(self.addonList.rowCount()))
 
     def onUpdateCatalogFinished(self, addons):
         print("retrieved list of addons: {}".format(len(addons)))

--- a/modules/application.py
+++ b/modules/application.py
@@ -35,10 +35,6 @@ class Grid(Qt.QTableWidget):
         row=self.currentRow()
         name=self.item(row,0).text()
         self.menu.addAction(self.tr("Context menu for {}").format(name))
-        removefromlistAction = Qt.QAction(self.tr("Remove from list"),self)
-        removefromlistAction.setStatusTip(self.tr("Leave all files unaltered, useful for subaddons"))
-        removefromlistAction.triggered.connect(self.removeFromList)
-        self.menu.addAction(removefromlistAction)
         actionUpdate = Qt.QAction(self.tr("Update addon"), self)
         actionUpdate.setStatusTip(self.tr("Update currently selected addons if needed"))
         actionUpdate.triggered.connect(self.parent.updateAddon)        
@@ -47,12 +43,11 @@ class Grid(Qt.QTableWidget):
         actionForceUpdate.setStatusTip(self.tr("Unconditionally update currently selected addons"))
         actionForceUpdate.triggered.connect(self.parent.forceUpdateAddon)        
         self.menu.addAction(actionForceUpdate)
+        actionRemovefromlist = Qt.QAction(self.tr("Remove addon from list"),self)
+        actionRemovefromlist.setStatusTip(self.tr("Leave all files unaltered, useful for subaddons"))
+        actionRemovefromlist.triggered.connect(self.parent.removeFromList)
+        self.menu.addAction(actionRemovefromlist)
         self.menu.popup(Qt.QCursor.pos())
-
-    def removeFromList(self):
-        row = self.currentRow()
-        self.removeRow(row)
-        self.parent.saveAddons()
         
         
 
@@ -148,6 +143,11 @@ class MainWidget(Qt.QMainWindow):
         actionUpdate.setStatusTip(self.tr("Update currently selected addons if needed"))
         actionUpdate.triggered.connect(self.updateAddon)
 
+        actionRemovefromlist = Qt.QAction(self.tr("Remove addon from list"),self)
+        actionRemovefromlist.setShortcut(Qt.QKeySequence.Delete)
+        actionRemovefromlist.setStatusTip(self.tr("Leave all files unaltered, useful for subaddons"))
+        actionRemovefromlist.triggered.connect(self.removeFromList)
+
         actionAdd = Qt.QAction(self.tr("Add addon"), self)
         actionAdd.setStatusTip(self.tr("Add a new addon"))
         actionAdd.triggered.connect(self.addAddon)
@@ -167,6 +167,7 @@ class MainWidget(Qt.QMainWindow):
         menuAddons.addSeparator()
         menuAddons.addAction(actionUpdateAll)
         menuAddons.addAction(actionUpdate)
+        menuAddons.addAction(actionRemovefromlist)
         menuAddons.addSeparator()
         menuAddons.addAction(actionAdd)
         menuAddons.addAction(actionRemove)
@@ -473,6 +474,11 @@ class MainWidget(Qt.QMainWindow):
         with open(defines.LCURSE_ADDON_TOCS_CACHE, "w") as f:
             json.dump(tocversions, f,indent=1)
         return tocversions
+
+    def removeFromList(self):
+        row = self.addonList.currentRow()
+        self.addonList.removeRow(row)
+        self.saveAddons()
 
     def removeAddon(self):
         row = self.addonList.currentRow()

--- a/modules/application.py
+++ b/modules/application.py
@@ -244,7 +244,7 @@ class MainWidget(Qt.QMainWindow):
         version_re = re.compile(r"^## *Version: *(.*)$")
         curse_re = re.compile(r"^## °X-Curse-Project-ID: *(.*)")
         tocversion_re = re.compile(r"^## *Interface: *(\d*)")
-        with open(toc, encoding="utf8", errors='replace') as f:
+        with open(toc, encoding="utf-8-sig", errors='replace') as f:
             line = f.readline()
             while line != "":
                 line = line.strip()

--- a/modules/application.py
+++ b/modules/application.py
@@ -200,6 +200,7 @@ class MainWidget(Qt.QMainWindow):
 
         self.addonList.setColumnCount(5)
         self.addonList.setHorizontalHeaderLabels(["Name", "Url", "Version", "Toc", "Allow Beta"])
+        self.addonList.setSortingEnabled(True)
 
         self.resize(1070, 815)
         screen = Qt.QDesktopWidget().screenGeometry()
@@ -408,6 +409,8 @@ class MainWidget(Qt.QMainWindow):
     def saveAddons(self):
         print("Saving addons to ",self.addonsFile)
         addons = []
+        sortSection = self.addonList.horizontalHeader().sortIndicatorSection()
+        sortOrder = self.addonList.horizontalHeader().sortIndicatorOrder()
         self.addonList.sortItems(0)
         for row in iter(range(self.addonList.rowCount())):
             addons.append(dict(
@@ -417,6 +420,7 @@ class MainWidget(Qt.QMainWindow):
                 toc=str(self.addonList.item(row,3).text()),
                 allowbeta=bool(self.addonList.item(row, 4).checkState() == Qt.Qt.Checked)
             ))
+        self.addonList.sortItems(sortSection, sortOrder)
         data={}
         data['addons'] = addons
         data['dbversion'] = defines.LCURSE_DBVERSION

--- a/modules/application.py
+++ b/modules/application.py
@@ -153,6 +153,7 @@ class MainWidget(Qt.QMainWindow):
         actionAdd.triggered.connect(self.addAddon)
 
         actionRemove = Qt.QAction(self.tr("Remove addon"), self)
+        actionRemove.setShortcut("Shift+Del")
         actionRemove.setStatusTip(self.tr("Remove currently selected addon"))
         actionRemove.triggered.connect(self.removeAddon)
 

--- a/modules/application.py
+++ b/modules/application.py
@@ -110,6 +110,11 @@ class MainWidget(Qt.QMainWindow):
         actionExit.setStatusTip(self.tr("Exit application"))
         actionExit.triggered.connect(self.close)
 
+        actionClearCell = Qt.QAction(self.tr("Remove selected addon information"),self)
+        actionClearCell.setShortcut("Backspace")
+        actionClearCell.setStatusTip(self.tr("Clear specific addon information"))
+        actionClearCell.triggered.connect(self.clearCell)
+
         menuFile = menubar.addMenu(self.tr("General"))
         menuFile.addAction(actionLoad)
         menuFile.addAction(actionSave)
@@ -122,6 +127,7 @@ class MainWidget(Qt.QMainWindow):
         self.addAction(actionSave)
         self.addAction(actionPrefs)
         self.addAction(actionExit)
+        self.addAction(actionClearCell)
 
         actionCheckAll = Qt.QAction(self.tr("Check all addons"), self)
         actionCheckAll.setShortcut('Ctrl+Shift+A')
@@ -488,6 +494,10 @@ class MainWidget(Qt.QMainWindow):
         row = self.addonList.currentRow()
         self.addonList.removeRow(row)
         self.saveAddons()
+
+    def clearCell(self):
+        cell = self.addonList.currentItem()
+        cell.setText("")
 
     def removeAddon(self):
         row = self.addonList.currentRow()

--- a/modules/application.py
+++ b/modules/application.py
@@ -319,9 +319,13 @@ class MainWidget(Qt.QMainWindow):
                         continue
                     (name, uri, version, tocVersion) = tmp
                     row = self.addonList.rowCount()
-                    if not self.addonList.findItems(name, Qt.Qt.MatchExactly):
+                    addons = self.addonList.findItems(name, Qt.Qt.MatchExactly)
+                    if not addons:
                         self.addonList.setRowCount(row + 1)
                         self.insertAddon(row, name, uri, version, tocVersion, False)
+                    elif tocVersion:
+                        for addon in addons:
+                            self.addonList.item(addon.row(), 3).setText(tocVersion)
         self.addonList.resizeColumnsToContents()
         self.saveAddons()
 

--- a/modules/application.py
+++ b/modules/application.py
@@ -469,7 +469,7 @@ class MainWidget(Qt.QMainWindow):
         sortSection = self.addonList.horizontalHeader().sortIndicatorSection()
         sortOrder = self.addonList.horizontalHeader().sortIndicatorOrder()
         self.addonList.sortItems(0)
-        for row in iter(range(self.addonList.rowCount())):
+        for row in range(self.addonList.rowCount()):
             addons.append(dict(
                 name=str(self.addonList.item(row, 0).text()),
                 uri=str(self.addonList.item(row, 1).text()),
@@ -653,7 +653,7 @@ class MainWidget(Qt.QMainWindow):
         checkDlg.exec_()
 
     def checkAllAddonsForUpdate(self):
-        self.checkAddonsForUpdate(rows=iter(range(self.addonList.rowCount())))
+        self.checkAddonsForUpdate(rows=range(self.addonList.rowCount()))
 
     def onUpdateFinished(self, addon, result):
         if result:

--- a/modules/application.py
+++ b/modules/application.py
@@ -323,6 +323,7 @@ class MainWidget(Qt.QMainWindow):
                     if not addons:
                         self.addonList.setRowCount(row + 1)
                         self.insertAddon(row, name, uri, version, tocVersion, False)
+                        self.setRowColor(row, Qt.Qt.cyan)
                     elif tocVersion:
                         for addon in addons:
                             self.addonList.item(addon.row(), 3).setText(tocVersion)

--- a/modules/application.py
+++ b/modules/application.py
@@ -242,7 +242,7 @@ class MainWidget(Qt.QMainWindow):
         curse_title_re = re.compile(r"^## *X-Curse-Project-Name: *(.*)")
         curse_version_re = re.compile(r"^## *X-Curse-Packaged-Version: *(.*)")
         version_re = re.compile(r"^## *Version: *(.*)$")
-        curse_re = re.compile(r"^## °X-Curse-Project-ID: *(.*)")
+        curse_re = re.compile(r"^## *X-Curse-Project-ID: *(.*)")
         tocversion_re = re.compile(r"^## *Interface: *(\d*)")
         with open(toc, encoding="utf-8-sig", errors='replace') as f:
             line = f.readline()
@@ -296,7 +296,10 @@ class MainWidget(Qt.QMainWindow):
         
         uri = "https://www.curseforge.com/wow/addons/{}".format(name.lower().replace(" ", "-"))
         if curseId:
-            uri = "https://www.curseforge.com/wow/addons/{}".format(curseId)
+            if curseId.isdigit():
+                uri = "https://www.curseforge.com/projects/{}".format(curseId)
+            else:
+                uri = "https://www.curseforge.com/wow/addons/{}".format(curseId)
         
             #return ["", "", "", ""]
 

--- a/modules/application.py
+++ b/modules/application.py
@@ -68,7 +68,6 @@ class MainWidget(Qt.QMainWindow):
         settings = Qt.QSettings()
         try:
             buildinfo="{}/.build.info".format(settings.value(defines.WOW_FOLDER_KEY, defines.WOW_FOLDER_DEFAULT))
-            print(buildinfo)
             with open(buildinfo, encoding="utf8", errors='replace') as f:
                 line = f.readline()
                 if self.wowVersion == 'retail':
@@ -518,7 +517,8 @@ class MainWidget(Qt.QMainWindow):
             self.addonList.setItem(newrow, 4, allowBetaItem)
 
     def updateDatabaseFormat(self,oldVersion):
-        print("Db version is ", oldVersion, " vs ", defines.LCURSE_DBVERSION)
+        if oldVersion != defines.LCURSE_DBVERSION:
+            print("Db version is ", oldVersion, " vs ", defines.LCURSE_DBVERSION)
         if oldVersion >= defines.LCURSE_DBVERSION:
             return {}
         print("Database update!")

--- a/modules/application.py
+++ b/modules/application.py
@@ -221,7 +221,6 @@ class MainWidget(Qt.QMainWindow):
 
         self.addonList.setColumnCount(5)
         self.addonList.setHorizontalHeaderLabels(["Name", "Url", "Version", "Toc", "Allow Beta"])
-        self.addonList.setSortingEnabled(True)
 
         self.resize(1070, 815)
         screen = Qt.QDesktopWidget().screenGeometry()
@@ -399,6 +398,7 @@ class MainWidget(Qt.QMainWindow):
                 self.availableAddons = json.load(c)
 
     def loadAddons(self):
+        self.addonList.setSortingEnabled(False)
         self.addonList.clearContents()
         addons = None
         if os.path.exists(self.addonsFile):
@@ -449,6 +449,7 @@ class MainWidget(Qt.QMainWindow):
             self.addonList.setItem(row, 4, allowBetaItem)
         self.addonList.resizeColumnsToContents()
         self.adjustSize()
+        self.addonList.setSortingEnabled(True)
         
     def saveAddons(self):
         print("Saving addons to ",self.addonsFile)

--- a/modules/defines.py
+++ b/modules/defines.py
@@ -15,7 +15,6 @@ LCURSE_MAXTHREADS_KEY = "Preferences/maxthreads"
 LCURSE_MAXTHREADS_DEFAULT = 50
 LCURSE_DBVERSION = 1
 TOC = "70100"
-print("Folders",WOW_FOLDER_KEY,WOW_FOLDER_DEFAULT)
 # with open(toc, encoding="utf8", errors='replace') as f:
 #     line = f.readline()
 #     while line != "":

--- a/modules/defines.py
+++ b/modules/defines.py
@@ -3,9 +3,11 @@ from PyQt5 import Qt
 WOW_FOLDER_KEY = "Preferences/wowfolder"
 WOW_TOC_KEY = "Preferences/CurrentToc"
 WOW_FOLDER_DEFAULT = "{}/.wine/drive_c/Program Files (x86)/World of Warcraft".format(Qt.QDir.homePath())
+WOW_VERSION_DEFAULT = "retail"
 
 LCURSE_FOLDER = "{}/.lcurse".format(Qt.QDir.homePath())
 LCURSE_ADDONS = LCURSE_FOLDER + "/addons.json"
+LCURSE_ADDONS_BASE = LCURSE_FOLDER + "/addons_{}.json"
 LCURSE_ADDON_CATALOG = LCURSE_FOLDER + "/addon-catalog.json"
 LCURSE_ADDON_TOCS_CACHE = LCURSE_FOLDER + "/tocs.json"
 

--- a/modules/preferences.py
+++ b/modules/preferences.py
@@ -7,8 +7,6 @@ class PreferencesDlg(Qt.QDialog):
         super(PreferencesDlg, self).__init__(parent)
         self.settings = Qt.QSettings()
 
-        print(defines)
-
         layout = Qt.QVBoxLayout(self)
 
         layout.addWidget(Qt.QLabel(self.tr("WoW Install Folder:"), self))

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -198,7 +198,7 @@ class CheckWorker(Qt.QThread):
                 if self.wowVersion == 'classic':
                     while versionIdx < len(lis):
                         version = tuple(lis[versionIdx].findAll('td')[4].stripped_strings)
-                        if int(version[0][0]) == 1 or len(version) > 7 and version[1][0] == '+':
+                        if int(version[0][0]) == 1 or len(version) > 1 and int(version[0][0]) > 7 and version[1][0] == '+':
                             isOk = beta or lis[versionIdx].td.div.span.string=='R'
                             if isOk:
                                 break

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -2,7 +2,6 @@ from PyQt5 import Qt
 from bs4 import BeautifulSoup
 import urllib.parse
 import cfscrape
-from http import cookiejar
 import zipfile
 from modules import defines
 import os

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -198,7 +198,6 @@ class CheckWorker(Qt.QThread):
                 if self.wowVersion == 'classic':
                     while versionIdx < len(lis):
                         version = tuple(lis[versionIdx].findAll('td')[4].stripped_strings)
-                        print(version)
                         if int(version[0][0]) == 1 or len(version) > 7 and version[1][0] == '+':
                             isOk = beta or lis[versionIdx].td.div.span.string=='R'
                             if isOk:

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -388,20 +388,21 @@ class UpdateCatalogWorker(Qt.QThread):
 
         lastpage = 1
         if page == 1:
-            pager = soup.select("ul.b-pagination-list.paging-list.j-tablesorter-pager.j-listing-pagination li")
+            pager = soup.select("a.pagination-item span")
             if pager:
-                lastpage = int(pager[len(pager) - 2].contents[0].contents[0])
+                lastpage = int(pager[len(pager) - 1].contents[0])
 
-        projects = soup.select("li.project-list-item")  # li .title h4 a")
+        projects = soup.select("div.project-listing-row")
         self.addonsMutex.lock()
         for project in projects:
-            links=project.select("a.button--download")
-            texts=project.select("a h2")
+            links=project.select("a.button--hollow")
+            texts=project.select("a h3")
             for text in texts:
                 nome=text.string.replace('\\r','').replace('\\n','').strip()
                 break
             for link in links:
-                href=link.get("href", link.get("data-normal-href")).replace("/download",'')
+                href=link.get("href", link.get("data-normal-href")).replace("/woW/", "/wow/").replace("/download",'')
+                break
             self.addons.append([nome, "https://www.curseforge.com{}".format(href)])
         self.progress.emit(len(self.addons))
         self.addonsMutex.unlock()

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -19,12 +19,12 @@ scraper = cfscrape.create_scraper()
 
 # Debug helper: caches html page to not hammer server while testing/debugging/coding    
 class CachedResponse:
-    data = ""
+    content = ""
     def __init__(self,data):
-        self.data=data
+        self.content=data
         
     def read(self):
-        return self.data
+        return self.content
 
 # Debug helper: caches html page to not hammer server while testing/debugging/coding    
 class CacheDecorator(object):
@@ -41,7 +41,7 @@ class CacheDecorator(object):
         except:
             response = self.fun(url)
             f = open(self.cachePrefix +  hash, "w")
-            f.write(str(response.read()))
+            f.write(response.text)
             f.close()
             return response            
             

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -2,6 +2,7 @@ from PyQt5 import Qt
 from bs4 import BeautifulSoup
 import urllib.parse
 import cfscrape
+from requests.exceptions import RequestException
 import zipfile
 from modules import defines
 import os
@@ -217,6 +218,8 @@ class CheckWorker(Qt.QThread):
                     downloadLink = "https://www.curseforge.com/wow/addons/" + addonname + "/download/" + addonid + "/file"
                     return (True, (version, downloadLink))
             return (False, ("", ""))
+        except RequestException as e:
+            print("Curse Update Exception",e)
         except Exception as e:
             print(e)
         return (False, None)

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -194,9 +194,11 @@ class CheckWorker(Qt.QThread):
                 versionIdx = 1
                 isOk=False
                 while True:
-                    isOk= beta or lis[versionIdx].td.div.span.string=='R'
-                    if isOk:
-                        break
+                    version = tuple(lis[versionIdx].findAll('td')[4].stripped_strings)
+                    if int(version[0][0]) > 1 or len(version) > 1 and version[1][0] == '+':
+                        isOk = beta or lis[versionIdx].td.div.span.string=='R'
+                        if isOk:
+                            break
                     versionIdx=versionIdx+1
                 row=lis[versionIdx]
                 elem = row.find("a",attrs={"data-action":"file-link"})

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -380,7 +380,7 @@ class UpdateCatalogWorker(Qt.QThread):
         self.lastpage = 1
 
     def retrievePartialListOfAddons(self, page):
-        response = OpenWithRetry("http://www.curseforge.com/wow/addons?page={}".format(page))
+        response = OpenWithRetry("https://www.curseforge.com/wow/addons?page={}".format(page))
         soup = BeautifulSoup(response.read(), "lxml")
         # Curse returns a soft-500
         if soup.find_all("h2", string="Error"):
@@ -402,7 +402,7 @@ class UpdateCatalogWorker(Qt.QThread):
                 break
             for link in links:
                 href=link.get("href", link.get("data-normal-href")).replace("/download",'')
-            self.addons.append([nome, "http://www.curseforge.com{}".format(href)])
+            self.addons.append([nome, "https://www.curseforge.com{}".format(href)])
         self.progress.emit(len(self.addons))
         self.addonsMutex.unlock()
 


### PR DESCRIPTION
I've just pushed my local changes to Github, in the hope that it may help others. I haven't split them up in separate branches/pulls, so feel free to pick & match if you're interested. I can also do some splitting up if that would help.

Probably good to note: I've only run this on Python 3.7 (and not with pipenv). I would imagine it works fine with pipenv on Python 3.6, though.

Summary of changes:
- Added keyboard shortcuts (`Del` for "Remove from list", `Shift+Del` for "Remove addon", `Backspace` to clear a cell)
- Small import QOL improvements (Cyan background for newly imported addons, always update Interface version from TOC files)
- Sortable columns **[#13]**
- Fixed some TOC parsing errors (problems with [BOM](https://en.wikipedia.org/wiki/Byte_order_mark)s and Curse Project IDs)
- Changes to work with latest curseforge.com (HTTPS URLs, HTML structure changes) **[#75]**
- Very basic and naive support for WoW Classic and checking whether an addon is for Classic or not (but it works) **[#78, #79]**