### PR TITLE
Fix errors thrown during needsGitUpdate and doGitUpdate.

### DIFF
--- a/modules/application.py
+++ b/modules/application.py
@@ -657,13 +657,15 @@ class MainWidget(Qt.QMainWindow):
 
     def onUpdateFinished(self, addon, result):
         if result:
+            tmp=None
             toc=str(addon[6])
             if os.path.exists(toc):
                 tmp = self.extractAddonMetadataFromTOC(toc)
             data = self.addonList.item(addon[0], 0).data(Qt.Qt.UserRole)
             self.addonList.item(addon[0], 2).setText(data[0])
-            self.addonList.item(addon[0], 3).setText(tmp[3])
-            if (tmp[3] < defines.TOC):
+            if tmp:
+                self.addonList.item(addon[0], 3).setText(tmp[3])
+            if (tmp and tmp[3] < defines.TOC):
                 self.addonList.item(addon[0], 3).setForeground(Qt.Qt.red)
             else:
                 self.addonList.item(addon[0], 3).setForeground(Qt.Qt.blue)

--- a/modules/waitdlg.py
+++ b/modules/waitdlg.py
@@ -169,7 +169,8 @@ class CheckWorker(Qt.QThread):
         try:
             settings = Qt.QSettings()
             dest = "{}/_{}_/Interface/AddOns/{}".format(
-                settings.value(defines.WOW_FOLDER_KEY, self.wowVersion, defines.WOW_FOLDER_DEFAULT),
+                settings.value(defines.WOW_FOLDER_KEY, defines.WOW_FOLDER_DEFAULT),
+                self.wowVersion,
                 os.path.basename(str(self.addon[2])[:-4]))
             originCurrent = str(check_output(["git", "ls-remote", str(self.addon[2]), "HEAD"]), "utf-8").split()[0]
             localCurrent = self.addon[3]
@@ -300,7 +301,12 @@ class UpdateWorker(Qt.QThread):
             else:
                 os.chdir(destAddon)
                 check_call(["git", "pull"])
-            return True
+            toc = None
+            for filename in os.listdir(destAddon):
+                if filename[-4:] == '.toc':
+                    toc = '{}/{}'.format(destAddon, filename)
+                    break
+            return True, toc
         except Exception as e:
             print("DoGitUpdate",e)
         return False


### PR DESCRIPTION
Noticed #82 and decided to take a look at how it works. Ran into a few problems:

* Oops regarding arguments in needsGitUpdate.
* Handling of non-existant tmp variable in onUpdateFinished.
* Returning TOC location in doGitUpdate.